### PR TITLE
Required parameter after optional parameter is deprecated

### DIFF
--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -83,7 +83,7 @@ class ImageRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
      * @param array $conf TypoScript configuration
      * @return string HTML output
      */
-    public function renderImageAttributes($content = '', $conf)
+    public function renderImageAttributes($content, $conf)
     {
         $imageAttributes = $this->getImageAttributes();
 


### PR DESCRIPTION
PHP has deprecated the usage of optional call arguments before required call arguments. Anyway initializing `$content` to an empty string is not useful.